### PR TITLE
Multiple fixes for MMD flow

### DIFF
--- a/examples/plot_simple_gaussian.py
+++ b/examples/plot_simple_gaussian.py
@@ -43,7 +43,7 @@ x_svgd, svgd_traj, _ = svgd(
 )
 
 x_mmd, mmd_traj, _ = mmd_lbfgs(
-    x.clone(), sampler(3 * n_samples), bw=bw, store=True
+    x.clone(), sampler(100 * n_samples), bw=bw, store=True
 )
 
 labels = ["KSD L-BFGS", "KSD Grad", "SVGD", "MMD"]

--- a/examples/plot_simple_gaussian.py
+++ b/examples/plot_simple_gaussian.py
@@ -25,7 +25,7 @@ def potential(x):
 
 
 def sampler(n_points):
-    return math.sqrt(0.3) * torch.randn(n_points, 1)
+    return math.sqrt(0.3) * torch.randn(n_points, 2)
 
 
 n_samples = 50

--- a/ksddescent/contenders.py
+++ b/ksddescent/contenders.py
@@ -166,7 +166,7 @@ def mmd_lbfgs(x0, target_samples, bw=1, max_iter=10000, tol=1e-5,
     '''
     x = x0.clone().detach().numpy()
     n_samples, p = x.shape
-    k_yy = gaussian_kernel(target_samples, target_samples, bw).sum().item()
+    k_yy = gaussian_kernel(target_samples, target_samples, bw).mean().item()
     if store:
         class callback_store():
             def __init__(self):
@@ -191,8 +191,8 @@ def mmd_lbfgs(x0, target_samples, bw=1, max_iter=10000, tol=1e-5,
         x_numpy = x_numpy.reshape(n_samples, p)
         x = torch.tensor(x_numpy, dtype=torch.float32)
         x.requires_grad = True
-        k_xx = gaussian_kernel(x, x, bw).sum()
-        k_xy = gaussian_kernel(x, target_samples, bw).sum()
+        k_xx = gaussian_kernel(x, x, bw).mean()
+        k_xy = gaussian_kernel(x, target_samples, bw).mean()
         loss = k_xx - 2 * k_xy + k_yy
         loss.backward()
         grad = x.grad


### PR DESCRIPTION
Changes implemented:

* target samples for MMD flow are now sampled from 2d Gaussian (previously: 1d Gaussian)
* fix empirical estimator for MMD to avoid variance collapse when number of targets samples != number of particles
* increase number of target samples for MMD flow Gaussian example

Please, see the chart which compares flow generated by the existing code and the one after changes made.

![mmd_flow](https://github.com/pierreablin/ksddescent/assets/485647/aa2b607d-fbc6-435f-9448-76b84a3b2910)
